### PR TITLE
Call input poll callback

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -889,6 +889,7 @@ unsigned retro_get_region(void)
 
 void retro_run(void)
 {
+    input_poll_cb();
     bool update_varaibles = false;
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &update_varaibles))
     {


### PR DESCRIPTION
Withoput calling the input poll callback there was no input in "normal" input polling mode in retroarch.