### PR TITLE
File io performance

### DIFF
--- a/core/common/files.c
+++ b/core/common/files.c
@@ -979,7 +979,7 @@ int file_exists( const char * filename )
 {
     file * fp ;
 
-    fp = file_open( filename, "rb" ) ;
+    fp = file_open( filename, "rb0" ) ;
     if ( fp )
     {
         file_close( fp ) ;

--- a/libretro/filesystem.h
+++ b/libretro/filesystem.h
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include "file/file_path.h"
 
-void init_filesystem(const char * initial_directory, const char * save_dir, struct retro_vfs_interface_info* vfs_info);
+void init_filesystem(const char * initial_directory, const char * save_dir, struct retro_vfs_interface_info* vfs_info, bool in_case_insensitive_io);
 void cleanup_filesystem();
 
 char * get_content_basename();

--- a/libretro/filesystem.h
+++ b/libretro/filesystem.h
@@ -8,3 +8,8 @@ void cleanup_filesystem();
 
 char * get_content_basename();
 
+struct RFILE * fopen_libretro ( const char * filename, const char * mode );
+int fclose_libretro ( struct RFILE * stream );
+size_t fread_libretro(void *ptr, size_t size, size_t nmemb, struct RFILE *stream);
+int fseek_libretro(struct RFILE *stream, long int offset, int whence);
+size_t fwrite_libretro(const void *ptr, size_t size, size_t nmemb, struct RFILE *stream);

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -499,12 +499,12 @@ static bool get_boolean_option(const char* option_name, bool default_value)
     const char * value = get_option_value(option_name);
     if (value)
     {
-        if (string_is_equal_case_insensitive(value, "true")==0)
+        if (string_is_equal_case_insensitive(value, "true"))
         {
             return true;
         }
 
-        if (string_is_equal_case_insensitive(value, "false")==0)
+        if (string_is_equal_case_insensitive(value, "false"))
         {
             return false;
         }

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -75,6 +75,7 @@ int bennugd_content_height=0;
 char* libretro_base_dir;
 bool retro_enable_frame_limiter=true;
 bool force_frame_limiter=false;
+bool case_insensitive_file_io=true;
 
 typedef enum enum_libretro_scale_mode_override
 {
@@ -135,6 +136,8 @@ typedef struct mouse_button_mapping
 #define BGD_CORE_OPTION(a) "bennugd_"a
 
 const char * force_frame_limiter_opt = BGD_CORE_OPTION("force_frame_limiter");
+
+const char * case_insensitive_file_io_opt = BGD_CORE_OPTION("case_insensitive_file_io");
 
 const char* override_scaling_opt = BGD_CORE_OPTION("override_scaling");
 const char* override_scaling_off_optval = "off";
@@ -289,6 +292,16 @@ static void set_core_options()
                 { override_scaling_2xunfiltered_optval, "2X Unfiltered"},
                 { NULL, NULL}
             }
+        },
+        {
+            .key =  case_insensitive_file_io_opt,
+            .desc= "Emulate case insensitive filesystem",
+            .info = "Emulate dealing with file names a case insensitive way even though the underlying filesystem is case sensitive.\n"
+                    "Changes take affect when reloading content.\n"
+                    "This can hurt io performance.\n"
+            ,
+            .default_value = "true",
+            .values = { { "true", "True"}, { "false", "False"}, { NULL, NULL} }
         },
         {
             .key = mouse_emulation_opt,
@@ -565,6 +578,9 @@ static void update_variables()
             scale_override = libretro_scale_mode_override_off;
         }
     }
+
+    // Case insensitive file io emulation
+    case_insensitive_file_io = get_boolean_option(case_insensitive_file_io_opt, true);
 
     // Mouse emulation mode
     {
@@ -853,7 +869,7 @@ bool retro_load_game(const struct retro_game_info *info)
         environ_cb(RETRO_ENVIRONMENT_GET_SYSTEM_DIRECTORY, &save_dir);
     }
 
-    init_filesystem( info->path, save_dir, &retro_vfs_interface_info );
+    init_filesystem( info->path, save_dir, &retro_vfs_interface_info, case_insensitive_file_io);
 
     environ_cb(RETRO_ENVIRONMENT_SET_FRAME_TIME_CALLBACK, &(struct retro_frame_time_callback)
     {


### PR DESCRIPTION
This adds an option to turn off emulation of a case insensitive filesystem which will boost speed of content loading. This will be quite noticeable on android due to more overhead on file io. 

Also:
- boolen option parsing was broken
- updated usage of file io layer to be used in gzip file io versions
- improved performance if file existence checks by not trying to open files as a gzip stream first