### PR TITLE
Improve performance of case insensitive filesystem emulation

### DIFF
--- a/libretro/CMakeLists.txt
+++ b/libretro/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(bennugd_libretro SHARED
     ${libretro-common_SOURCE_DIR}/encodings/encoding_utf.c
     ${libretro-common_SOURCE_DIR}/time/rtime.c
     ${libretro-common_SOURCE_DIR}/compat/compat_strl.c
+    ${libretro-common_SOURCE_DIR}/compat/compat_strldup.c
     ${libretro-common_SOURCE_DIR}/streams/file_stream.c
     ${libretro-common_SOURCE_DIR}/streams/trans_stream_zlib.c
     ${libretro-common_SOURCE_DIR}/streams/file_stream_transforms.c

--- a/libretro/filesystem.c
+++ b/libretro/filesystem.c
@@ -88,7 +88,7 @@ static void create_file_map(const char* root_dir, char * directory_name, char* b
 
             file_map_t* entry = RHMAP_PTR_STR(file_map, buffer);
             buffer_used = *directory_name ? snprintf(buffer, buffer_size, "%s%s/%s", root_dir, directory_name, entry_name) : snprintf(buffer, buffer_size, "%s%s", root_dir, entry_name);
-            entry->real_name = strldup(buffer, buffer_used);
+            entry->real_name = strldup(buffer, buffer_used+1);
             entry->is_dir = retro_dirent_is_dir(dir, NULL);
 
             if (entry->is_dir)

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -296,9 +296,8 @@ static void set_core_options()
         {
             .key =  case_insensitive_file_io_opt,
             .desc= "Emulate case insensitive filesystem",
-            .info = "Emulate dealing with file names a case insensitive way even though the underlying filesystem is case sensitive.\n"
+            .info = "Emulate dealing with file names in a case insensitive way even though the underlying filesystem is case sensitive.\n"
                     "Changes take affect when reloading content.\n"
-                    "This can hurt io performance.\n"
             ,
             .default_value = "true",
             .values = { { "true", "True"}, { "false", "False"}, { NULL, NULL} }


### PR DESCRIPTION
The case insensitive filesystem emulation cause a performance problem on android by doing an excessive amount of calls to enumerate directory entries.  So this PR introduces a cache to eliminate the performance problems.